### PR TITLE
Fix: Trainer and agent fixes for hidden layers + input fixes

### DIFF
--- a/traffic_agent/activation_functions.py
+++ b/traffic_agent/activation_functions.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+
+# Standard sigmoid activation function
+def sigmoid(input):
+    return 1/(1+np.exp(-input))
+
+
+# Standard relu
+def relu(x):
+    return (x > 0) * x

--- a/traffic_agent/trainer.py
+++ b/traffic_agent/trainer.py
@@ -79,8 +79,10 @@ class Trainer():
             # Our weighted probability of choosing a fitness score
             # is based upon the lowest fitness score, but we want
             # that to have the highest weight. So we need to take the
-            # inverse of that score to offset the weight.
-            weighted_fitness_scores = [1/(x) for x in fitness_scores]
+            # difference between the max and the current score, which
+            # gives us a range from 0 -> our lowest score by difference.
+            # This preserves linearity as well.
+            weighted_fitness_scores = [max(fitness_scores)-x for x in fitness_scores]
 
             new_population: List[NNAgent] = []
             if self.crossover > 0:


### PR DESCRIPTION
This introduces fixes.

* Detector inputs are scaled differently, more like how we originally intended
* Detector values are kept to the last 5, not the first 5 (which was an obvious bug)
* Hidden layers are utilized during inference - they were being ignored prior
* Trainer fitness scores are calculated by `max(input) - x` instead of `1/x`, which maintains linearity.
* Activation functions are imported and changeable on the hidden layers